### PR TITLE
Enhancements and Fixes: CAS expressions, Nodes management, and Authoring improvements

### DIFF
--- a/classes/class.assStackQuestionGUI.php
+++ b/classes/class.assStackQuestionGUI.php
@@ -418,16 +418,22 @@ class assStackQuestionGUI extends assQuestionGUI
     }
 
     /**
+     * @param bool $always
+     * @return int
      * @throws ilCtrlException
+     * @throws ilTaxonomyException
+     * @throws ilTestQuestionPoolInvalidArgumentException
      * @throws stack_exception
      */
-    public function writePostData($always = FALSE): int
+    public function writePostData(bool $always = FALSE): int
 	{
-        $authoring_ui = new StackQuestionAuthoringUI($this->plugin, $this->object, $this);
+        $hasErrors = !$always && $this->editQuestion(true);
 
-        $authoring_ui->writePostData();
+        if (!$hasErrors) {
+            return 0;
+        }
 
-        return 0;
+        return 1;
 	}
 
 	/**
@@ -463,10 +469,13 @@ class assStackQuestionGUI extends assQuestionGUI
      * Creates an output of the edit form for the question
      *
      * @param bool $check_only
+     * @return bool
      * @throws ilCtrlException
+     * @throws ilTaxonomyException
+     * @throws ilTestQuestionPoolInvalidArgumentException
      * @throws stack_exception
      */
-	public function editQuestion(bool $check_only = false): void
+	public function editQuestion(bool $check_only = false): bool
     {
 		global $DIC;
 
@@ -478,7 +487,17 @@ class assStackQuestionGUI extends assQuestionGUI
 
 		$authoring_gui = new StackQuestionAuthoringUI($this->plugin, $this->object, $this);
 
-        $this->tpl->setVariable("QUESTION_DATA", $authoring_gui->showAuthoringPanel());
+        list($errors, $form) = $authoring_gui->showAuthoringPanel();
+
+        if ($errors) {
+            $check_only = false;
+        }
+
+        if (!$check_only) {
+            $this->tpl->setVariable("QUESTION_DATA", $form);
+        }
+
+        return $errors;
 	}
 
 	/* RTE, Javascript, Ajax, jQuery etc. METHODS BEGIN */

--- a/classes/ui/Component/Input/Field/class.CasExpression.php
+++ b/classes/ui/Component/Input/Field/class.CasExpression.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the STACK Question plugin for ILIAS, an advanced STEM assessment tool.
+ *  This plugin is developed and maintained by SURLABS and is a port of STACK Question for Moodle,
+ *  originally created by Chris Sangwin.
+ *
+ *  The STACK Question plugin for ILIAS is open-source and licensed under GPL-3.0.
+ *  For license details, visit https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ *  To report bugs or participate in discussions, visit the Mantis system and filter by
+ *  the category "STACK Question" at https://mantis.ilias.de.
+ *
+ *  More information and source code are available at:
+ *  https://github.com/surlabs/STACK
+ *
+ *  If you need support, please contact the maintainer of this software at:
+ *  stack@surlabs.es
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field;
+
+use ILIAS\Data\Factory;
+use ILIAS\UI\Implementation\Component\Input\Field\Text;
+
+/**
+ * Class CasExpression
+ */
+class CasExpression extends Text
+{
+    public function __construct(
+        Factory $data_factory,
+        \ILIAS\Refinery\Factory $refinery,
+        string $label,
+        ?string $byline = null
+    ) {
+        $this->data_factory = $data_factory;
+        $this->refinery = $refinery;
+        $this->label = $label;
+        $this->byline = $byline;
+    }
+}

--- a/classes/ui/Component/class.CustomFactory.php
+++ b/classes/ui/Component/class.CustomFactory.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component;
 
 use Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field\ButtonSection;
+use Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field\CasExpression;
 use Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field\ColumnSection;
 use Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field\ExpandableSection;
 use Customizing\global\plugins\Modules\TestQuestionPool\Questions\assStackQuestion\classes\ui\Component\Input\Field\Legacy;
@@ -76,5 +77,22 @@ class CustomFactory
     public function taxonomySelect(ilObjTaxonomy $taxonomy): TaxonomySelect
     {
         return new TaxonomySelect($taxonomy);
+    }
+
+    public function casExpression(
+        string $label,
+        ?string $byline = null
+    ): CasExpression {
+        global $DIC;
+
+        $data_factory = new \ILIAS\Data\Factory();
+        $refinery = $DIC->refinery();
+
+        return new CasExpression(
+            $data_factory,
+            $refinery,
+            $label,
+            $byline
+        );
     }
 }

--- a/classes/ui/author/class.StackQuestionAuthoringUI.php
+++ b/classes/ui/author/class.StackQuestionAuthoringUI.php
@@ -583,7 +583,7 @@ class StackQuestionAuthoringUI
             3 => $this->plugin->txt('show_validation_yes_compact')
         ], $this->plugin->txt("input_show_validation_info"))->withRequired(true)
             ->withValue($input->get_parameter('showValidation'));
-        $inputs["options"] = $this->factory->input()->field()->text($this->plugin->txt("input_options"), $this->plugin->txt("input_options_info"))
+        $inputs["options"] = $this->customFactory->casExpression($this->plugin->txt("input_options"), $this->plugin->txt("input_options_info"))
             ->withValue($input->get_parameter('options'));
 
         $this->ctrl->setParameterByClass("assStackQuestionGUI", "input_name", $name);
@@ -710,9 +710,9 @@ class StackQuestionAuthoringUI
 
         $inputs["answer_test"] = $this->factory->input()->field()->select($this->plugin->txt("prt_node_answer_test"), $answer_test_choices, $this->plugin->txt("prt_node_answer_test_info"))->withRequired(true)
             ->withValue($node->answertest);
-        $inputs["student_answer"] = $this->factory->input()->field()->text($this->plugin->txt("prt_node_student_answer"), $this->plugin->txt("prt_node_student_answer_info"))->withRequired(true)
+        $inputs["student_answer"] = $this->customFactory->casExpression($this->plugin->txt("prt_node_student_answer"), $this->plugin->txt("prt_node_student_answer_info"))->withRequired(true)
             ->withValue($node->sans);
-        $inputs["teacher_answer"] = $this->factory->input()->field()->text($this->plugin->txt("prt_node_teacher_answer"), $this->plugin->txt("prt_node_teacher_answer_info"))->withRequired(true)
+        $inputs["teacher_answer"] = $this->customFactory->casExpression($this->plugin->txt("prt_node_teacher_answer"), $this->plugin->txt("prt_node_teacher_answer_info"))->withRequired(true)
             ->withValue($node->tans);
         $inputs["options"] = $this->factory->input()->field()->text($this->plugin->txt("prt_node_options"), $this->plugin->txt("prt_node_options_info"))
             ->withValue($node->testoptions);

--- a/classes/ui/author/class.StackQuestionAuthoringUI.php
+++ b/classes/ui/author/class.StackQuestionAuthoringUI.php
@@ -336,6 +336,7 @@ class StackQuestionAuthoringUI
         return match ($params["action"]) {
             "copyPrt" => $this->copyPrt($params["prt_name"]),
             "pastePrt" => $this->pastePrt(),
+            "createNode" => $this->createNode($params["prt_name"]),
             "deleteNode" => $this->deleteNode($params["prt_name"], $params["node_name"]),
             "copyNode" => $this->copyNode($params["prt_name"], $params["node_name"]),
             "pasteNode" => $this->pasteNode($params["to_prt_name"]),
@@ -711,6 +712,9 @@ class StackQuestionAuthoringUI
             ->withValue($node->quiet);
 
         $actions = [
+            $this->factory->button()->standard($this->plugin->txt("create_node"), "")->withOnLoadCode(function ($id) use ($prt, $node) {
+                return $this->generateActionCode($id, "createNode", ["prt_name" => $prt->get_name(), "node_name" => $node->nodename]);
+            }),
             $this->factory->button()->standard($this->plugin->txt("delete_node"), "")->withOnLoadCode(function ($id) use ($prt, $node) {
                 return $this->generateActionCode($id, "deleteNode", ["prt_name" => $prt->get_name(), "node_name" => $node->nodename]);
             }),
@@ -881,6 +885,42 @@ class StackQuestionAuthoringUI
         return true;
     }
 
+    private function createNode(string $prt_name): bool
+    {
+        global $DIC;
+
+        if (!isset($this->question->prts[$prt_name])) {
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('node_create_error'), true);
+            return false;
+        }
+
+        $prt = $this->question->prts[$prt_name];
+
+        $max = 0;
+        foreach ($prt->get_nodes() as $temp_node_name => $temp_node) {
+            if ((int) $temp_node_name > $max) {
+                $max = (int) $temp_node_name;
+            }
+        }
+
+        $new_node_name = (string) ($max + 1);
+
+        assStackQuestionDB::_createStackPrtNode(
+            $this->question->getId(),
+            $prt_name,
+            $new_node_name
+        );
+
+        $nodes_from_db_array = assStackQuestionDB::_readPrtNodes($this->question->getId(), $prt_name);
+        $prt->setNodes($nodes_from_db_array);
+
+        $this->question->prts[$prt_name] = $prt;
+
+        assStackQuestionDB::_saveStackPRTs($this->question);
+
+        $DIC->ui()->mainTemplate()->setOnScreenMessage("success", $this->plugin->txt('node_created'), true);
+        return true;
+    }
     private function deleteNode(string $prt_name, string $node_name): bool
     {
         global $DIC;

--- a/classes/ui/author/class.StackQuestionAuthoringUI.php
+++ b/classes/ui/author/class.StackQuestionAuthoringUI.php
@@ -42,6 +42,7 @@ use ilLanguage;
 use ilObject;
 use ilObjTaxonomy;
 use ilTaxNodeAssignment;
+use ilTaxonomyException;
 use ilTestQuestionPoolInvalidArgumentException;
 use stack_abstract_graph_svg_renderer;
 use stack_ans_test_controller;
@@ -93,6 +94,7 @@ class StackQuestionAuthoringUI
     /**
      * @throws ilCtrlException
      * @throws stack_exception
+     * @throws ilTaxonomyException
      */
     private function buildForm(): StandardForm
     {
@@ -108,56 +110,44 @@ class StackQuestionAuthoringUI
         }
 
         return $this->factory->input()->container()->form()->standard(
-            $this->ctrl->getLinkTargetByClass("assStackQuestionGUI", "editQuestion"),
+            $this->ctrl->getLinkTargetByClass("assStackQuestionGUI", "save"),
             $sections
         );
     }
 
     /**
-     * @throws ilCtrlException|stack_exception
+     * @return array
+     * @throws ilCtrlException
+     * @throws ilTaxonomyException
+     * @throws ilTestQuestionPoolInvalidArgumentException
+     * @throws stack_exception
      */
-    public function showAuthoringPanel(): string
+    public function showAuthoringPanel(): array
     {
         $form = $this->buildForm();
-
-        $saving_info = "";
+        $errors = false;
 
         if ($this->request->getMethod() == "POST") {
             $form = $form->withRequest($this->request);
             $result = $form->getData();
 
             if($result) {
-                $saving_info = $this->save($result) ?? "";
+                $errors = $this->save($result);
                 $form = $this->buildForm();
+            } else {
+                $errors = true;
             }
         }
 
-        return $saving_info . $this->renderer->render($form);
-    }
-
-    /**
-     * @throws ilCtrlException
-     * @throws stack_exception
-     */
-    public function writePostData(): ?string
-    {
-        $form = $this->buildForm()->withRequest($this->request);
-
-        $result = $form->getData();
-
-        if($result){
-            return $this->save($result);
-        }
-
-        return null;
+        return [$errors, $this->renderer->render($form)];
     }
 
     /**
      * @throws stack_exception
      * @throws ilTestQuestionPoolInvalidArgumentException
-     * @throws \ilTaxonomyException
+     * @throws ilTaxonomyException
      */
-    private function save(array $result): ?string
+    private function save(array $result): bool
     {
         global $DIC;
 
@@ -180,7 +170,8 @@ class StackQuestionAuthoringUI
         if (empty($basic["question_note"])) {
             foreach (stack_cas_security::get_all_with_feature('random') as $random) {
                 if (strpos($basic["question_variables"], $random) !== false) {
-                    return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt("error_no_question_note")));
+                    $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt("error_no_question_note"), true);
+                    return true;
                 }
             }
         }
@@ -302,7 +293,8 @@ class StackQuestionAuthoringUI
         }
 
         if ($prts_array && !$all_formative && $total_value < 0.0000001) {
-            return $this->renderer->render($this->factory->messageBox()->failure('There is an error authoring your question. The $totalvalue, the marks available for the question, must be positive'));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", 'There is an error authoring your question. The $totalvalue, the marks available for the question, must be positive', true);
+            return true;
         }
 
         $prts = array();
@@ -333,13 +325,13 @@ class StackQuestionAuthoringUI
 
         $this->question->saveToDb();
 
-        return $this->renderer->render($this->factory->messageBox()->success($this->lng->txt('msg_obj_modified')));
+        return false;
     }
 
     /**
      * @throws stack_exception
      */
-    private function checkAction(array $params): string
+    private function checkAction(array $params): bool
     {
         return match ($params["action"]) {
             "copyPrt" => $this->copyPrt($params["prt_name"]),
@@ -594,7 +586,7 @@ class StackQuestionAuthoringUI
     }
 
     /**
-     * @throws stack_exception|ilCtrlException
+     * @throws stack_exception
      */
     private function buildPrtSection(): array
     {
@@ -628,7 +620,6 @@ class StackQuestionAuthoringUI
     }
 
     /**
-     * @throws ilCtrlException
      */
     private function buildPrt(stack_potentialresponse_tree_lite $prt): array
     {
@@ -649,7 +640,6 @@ class StackQuestionAuthoringUI
     }
 
     /**
-     * @throws ilCtrlException
      */
     private function buildPrtOptions(stack_potentialresponse_tree_lite $prt): array
     {
@@ -680,7 +670,6 @@ class StackQuestionAuthoringUI
     }
 
     /**
-     * @throws ilCtrlException
      */
     private function buildNodeSection(stack_potentialresponse_tree_lite $prt): array
     {
@@ -696,7 +685,6 @@ class StackQuestionAuthoringUI
     }
 
     /**
-     * @throws ilCtrlException
      */
     private function buildNode(stack_potentialresponse_tree_lite $prt, object $node): array
     {
@@ -846,18 +834,22 @@ class StackQuestionAuthoringUI
 
 
 
-    private function copyPrt(string $prt_name): string
+    private function copyPrt(string $prt_name): bool
     {
+        global $DIC;
+
         if(!isset($this->question->prts[$prt_name])) {
-            return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('copy_error_no_prt')));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('copy_error_no_prt'), true);
+            return false;
         }
 
         $_SESSION['copy_prt'] = $this->question->getId() . "_" . $prt_name;
 
-        return $this->renderer->render($this->factory->messageBox()->success($this->plugin->txt('prt_copied_to_clipboard')));
+        $DIC->ui()->mainTemplate()->setOnScreenMessage("success", $this->plugin->txt('prt_copied_to_clipboard'), true);
+        return true;
     }
 
-    private function pastePrt(): string
+    private function pastePrt(): bool
     {
         if (isset($_SESSION['copy_prt'])) {
             $raw_data = explode("_", $_SESSION['copy_prt']);
@@ -886,23 +878,28 @@ class StackQuestionAuthoringUI
             }
         }
 
-        return "";
+        return true;
     }
 
-    private function deleteNode(string $prt_name, string $node_name): string
+    private function deleteNode(string $prt_name, string $node_name): bool
     {
+        global $DIC;
+
         if(!isset($this->question->prts[$prt_name])) {
-            return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('deletion_error_no_prt')));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('deletion_error_no_prt'), true);
+            return false;
         }
 
         $prt = $this->question->prts[$prt_name];
 
         if (sizeof($prt->get_nodes()) < 2) {
-            return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('deletion_error_first_node')));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('deletion_error_first_node'), true);
+            return false;
         }
 
         if ((int)$prt->get_first_node() == (int) $node_name) {
-            return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('deletion_error_first_node')));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('deletion_error_first_node'), true);
+            return false;
         }
 
         $new_nodes = $prt->get_nodes();
@@ -924,22 +921,29 @@ class StackQuestionAuthoringUI
 
         assStackQuestionDB::_deleteStackPrtNodes($this->question->getId(), $prt_name, $node_name);
 
-        return $this->renderer->render($this->factory->messageBox()->success($this->plugin->txt('node_deleted')));
+        $DIC->ui()->mainTemplate()->setOnScreenMessage("success", $this->plugin->txt('node_deleted'), true);
+        return true;
     }
 
-    private function copyNode(string $prt_name, string $node_name): string
+    private function copyNode(string $prt_name, string $node_name): bool
     {
+        global $DIC;
+
         if(!isset($this->question->prts[$prt_name])) {
-            return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('copy_error_no_prt')));
+            $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('copy_error_no_prt'), true);
+            return false;
         }
 
         $_SESSION['copy_node'] = $this->question->getId() . "_" . $prt_name . "_" . $node_name;
 
-        return $this->renderer->render($this->factory->messageBox()->success($this->plugin->txt('node_copied_to_clipboard')));
+        $DIC->ui()->mainTemplate()->setOnScreenMessage("success", $this->plugin->txt('node_copied_to_clipboard'), true);
+        return true;
     }
 
-    private function pasteNode(string $to_prt_name): string
+    private function pasteNode(string $to_prt_name): bool
     {
+        global $DIC;
+
         if (isset($_SESSION['copy_node'])) {
             $raw_data = explode("_", $_SESSION['copy_node']);
             $original_question_id = $raw_data[0];
@@ -947,7 +951,8 @@ class StackQuestionAuthoringUI
             $original_node_name = $raw_data[2];
 
             if (!isset($this->question->prts[$to_prt_name])) {
-                return $this->renderer->render($this->factory->messageBox()->failure($this->plugin->txt('paste_error_no_prt')));
+                $DIC->ui()->mainTemplate()->setOnScreenMessage("failure", $this->plugin->txt('paste_error_no_prt'), true);
+                return false;
             }
 
             $prt = $this->question->prts[$to_prt_name];
@@ -955,7 +960,9 @@ class StackQuestionAuthoringUI
             $max = 0;
 
             foreach ($prt->get_nodes() as $temp_node_name => $temp_node) {
-                (int)$temp_node_name > $max ? $max = (int) $temp_node_name : "";
+                if ((int) $temp_node_name > $max) {
+                    $max = (int) $temp_node_name;
+                }
             }
 
             $new_node_name = $max + 1;
@@ -967,11 +974,11 @@ class StackQuestionAuthoringUI
             $prt->setNodes($nodes_from_db_array);
         }
 
-        return "";
+        return true;
     }
 
     /**
-     * @throws \ilTaxonomyException
+     * @throws ilTaxonomyException
      */
     private function buildTaxonomySection(): array
     {

--- a/classes/utils/class.assStackQuestionDB.php
+++ b/classes/utils/class.assStackQuestionDB.php
@@ -1224,7 +1224,54 @@ class assStackQuestionDB
         }
     }
 
-	/**
+    /**
+     * Create a new node for a given PRT in a question
+     *
+     * @param int $question_id
+     * @param string $prt_name
+     * @param string $node_name
+     * @return bool
+     */
+    public static function _createStackPrtNode(int $question_id, string $prt_name, string $node_name): bool
+    {
+        global $DIC;
+
+        try {
+            $DIC->database()->insert("xqcas_prt_nodes", array(
+                "id" => array("integer", $DIC->database()->nextId('xqcas_prt_nodes')),
+                "question_id" => array("integer", $question_id),
+                "prt_name" => array("text", $prt_name),
+                "node_name" => array("text", $node_name),
+                "answer_test" => array("text", "AlgEquiv"),
+                "sans" => array("text", "ans1"),
+                "tans" => array("text", "z"),
+                "test_options" => array("text", ""),
+                "quiet" => array("integer", 0),
+                "true_score_mode" => array("text", "="),
+                "true_score" => array("text", "1"),
+                "true_penalty" => array("text", "0"),
+                "true_next_node" => array("text", "-1"),
+                "true_answer_note" => array("text", $prt_name . '-' . $node_name . '-T'),
+                "true_feedback" => array("clob", ""),
+                "true_feedback_format" => array("integer", 0),
+                "false_score_mode" => array("text", "="),
+                "false_score" => array("text", "0"),
+                "false_penalty" => array("text", "0"),
+                "false_next_node" => array("text", "-1"),
+                "false_answer_note" => array("text", $prt_name . '-' . $node_name . '-F'),
+                "false_feedback" => array("clob", ""),
+                "false_feedback_format" => array("integer", 0),
+                "description" => array("clob", "")
+            ));
+
+            return true;
+        } catch (\Exception $e) {
+            $DIC->logger()->root()->error("Error creating node: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
 	 * @param int $question_id
 	 * @param string $prt_name
 	 * @param string $node_name

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -652,6 +652,8 @@ config_feedback_styles_changed_message#:#Die Standardeinstellungen für Feedback
 feedback_extra_1#:#Teilweise korrekt
 feedback_extra_1_info#:#Feedback-Style für teilweise korrekte Antworten
 copy_node#:#Knoten kopieren
+create_node#:#Knoten erstellen
+node_created#:#Knoten erstellt
 paste_node#:#Knoten einfügen
 copy_prt#:# Rückmeldebaum kopieren
 paste_prt#:#Rückmeldebaum einfügen
@@ -660,6 +662,7 @@ node_copied_to_clipboard#:#Knoten in die Zwischenablage kopiert
 node_paste#:#In dieser Frage wurde ein Knoten eingefügt
 prt_paste#:#In dieser Frage wurde ein Rückmeldebaum eingefügt
 prt_paste_error#:#Es gab einen Fehler beim Einfügen des PRT, vielleicht wurde das ursprüngliche PRT gelöscht
+node_create_error#:#Beim Erstellen des Knotens ist ein Fehler aufgetreten.
 srv_purpose#:#Verwendung
 srv_purpose_info#:#Wählen Sie "Testdurchlauf" um einen Maxima-Server exklusiv für zeitkritische Anfragen währen eines Tests zu reservieren, z.B. für E-Klausuren. Stellen Sie dann einen zweiten Server für alle anderen Anfragen bereit ("Erstellung/Bewertung").
 srv_purpose_run#:#Testdurchlauf

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -722,3 +722,4 @@ ui_admin_configuration_quality_check_prt_comma_errors_fixed#:#Die folgenden Frag
 ui_admin_configuration_quality_check_prt_comma_errors_fixed_count#:#Kommafehler korrigiert:
 fix#:#Korrigieren
 fix_all_comma_errors#:#Alle Kommafehler korrigieren
+node_deleted#:#Der Knoten wurde gelöscht.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -645,6 +645,8 @@ feedback_plot_feedback#:#Plot
 feedback_plot_feedback_info#:#Feedback style used for plots
 config_feedback_styles_changed_message#:#The default settings for Feedback Styles have been changed successfully.
 copy_node#:#Copy Node
+create_node#:#Create Node
+node_created#:#New Node created
 paste_node#:#Paste Node
 copy_prt#:#Copy Potential Response Tree
 paste_prt#:#Paste Potential Response Tree
@@ -653,6 +655,7 @@ node_copied_to_clipboard#:#Node copied to Clipboard
 node_paste#:#A Node has been pasted in this question
 prt_paste#:#A PRT has been pasted in this question
 prt_paste_error#:#There was an error pasting the PRT maybe the original PRT has been deleted
+node_create_error#:#There was an error creating the Node
 prt_created#:#New Potential Response Tree created
 srv_purpose#:#Purpose
 srv_purpose_info#:#Choose 'Test Run' to exclusivly reserve a maxima server for the time time-critical calls during a test, e.g. to support online exams. Then provide a second server for all other calls ('Authoring/Scoring').

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -716,3 +716,4 @@ ui_admin_configuration_quality_check_prt_comma_errors_fixed#:#The following ques
 ui_admin_configuration_quality_check_prt_comma_errors_fixed_count#:#Comma errors fixed:
 fix#:#Fix
 fix_all_comma_errors#:#Fix all comma errors
+node_deleted#:#Node deleted

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -719,3 +719,4 @@ ui_admin_configuration_quality_check_prt_comma_errors_fixed#:#Se han corregido l
 ui_admin_configuration_quality_check_prt_comma_errors_fixed_count#:#Errores de coma corregidos:
 fix#:#Corregir
 fix_all_comma_errors#:#Corregir todos los errores de coma
+node_deleted#:#El nodo ha sido eliminado.

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -649,6 +649,8 @@ config_feedback_styles_changed_message#:#La configuración predeterminada para e
 feedback_extra_1#:#Parcialmente correcto
 feedback_extra_1_info#:#Estilo de retroalimentación para respuestas parcialmente correctas
 copy_node#:#Copiar nodo
+create_node#:#Crear nodo
+node_created#:#El nodo ha sido creado.
 paste_node#:#Pegar nodo
 copy_prt#:#Copiar árboles de respuestas potenciales
 paste_prt#:#Pegar árboles de respuestas potenciales
@@ -657,6 +659,7 @@ node_copied_to_clipboard#:#Nodo copiado al portapapeles
 node_paste#:#Se ha pegado un nodo en esta pregunta
 prt_paste#:#Se ha pegado un árbole de respuestas potenciales en esta pregunta
 prt_paste_error#:#Hubo un error al pegar el PRT, tal vez el PRT original fue eliminado
+node_create_error#:#Hubo un error al crear el Nodo.
 srv_purpose#:#Uso
 srv_purpose_info#:#Seleccione "Ejecución de prueba" para reservar un servidor Maxima exclusivamente para solicitudes críticas durante una prueba, por ejemplo, para exámenes electrónicos. Luego, proporcione un segundo servidor para todas las demás solicitudes ("Creación/Evaluación").
 srv_purpose_run#:#Ejecución de prueba

--- a/plugin.php
+++ b/plugin.php
@@ -20,7 +20,7 @@
 
 $id = "xqcas";
  
-$version = "9.4.1";
+$version = "9.4.2";
 
 $ilias_min_version = "9.00";
 $ilias_max_version = "9.999";


### PR DESCRIPTION
## Summary
This PR introduces several important fixes and enhancements to the STACK for ILIAS plugin:

- **Fixes**
  - Prevented loss of information in inputs with CAS expressions.
  - Resolved issue where questions were not being saved in test mode.

- **Features**
  - Added a new "Create Node" button to improve question authoring workflow.

- **Refactoring**
  - Updated method signatures (`writePostData`, `editQuestion`, `showAuthoringPanel`, `save`, etc.) to return proper types and error flags.
  - Replaced inline form error messages with ILIAS onscreen message system.
  - Simplified node and PRT copy/paste actions to return `bool` instead of rendered strings.

- **Language Updates**
  - Added missing translations for node creation and deletion in **English**, **German**, and **Spanish**.

---
